### PR TITLE
Support Nightscout API tokens

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -8,8 +8,13 @@
 
     <group name="General">
         <entry name="nightscoutURL" type="String">
-            <label>Your Nightscout url (e.g. https://appname.herokuapp.com)</label>
             <default>https://appname.herokuapp.com</default>
+        </entry>
+        <entry name="nightscoutToken" type="String">
+            <default>plasmoid-0000000</default>
+        </entry>
+        <entry name="updateInterval" type="Int">
+            <default>5</default>
         </entry>
     </group>
 </kcfg>

--- a/contents/ui/CompactRepresentation.qml
+++ b/contents/ui/CompactRepresentation.qml
@@ -3,36 +3,24 @@ import QtQuick 2.0
 import QtQuick.Layouts 1.1
 import org.kde.plasma.plasmoid 2.0
 import org.kde.plasma.core 2.0 as PlasmaCore
-import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.components 3.0 as PlasmaComponents
 import org.kde.plasma.extras 2.0 as PlasmaExtras
 import org.kde.kquickcontrolsaddons 2.0
 
-GridLayout {
-    anchors.fill: parent
-    rows: 2
-    columns: 1
-
+ColumnLayout {
     PlasmaComponents.Label {
         id: currentBG
-
         text: "???"
-        Layout.alignment: center
-        font {
-            family: plasmoid.configuration.fontFamily || theme.defaultFont.family
-            weight: plasmoid.configuration.boldText ? Font.Bold : theme.defaultFont.weight
-            italic: plasmoid.configuration.italicText
-            pixelSize: 24
-        }
     }
+
     Timer {
         id: textTimer
-        interval: read_interval
+        interval: updateInterval * 60 * 1000
         repeat: true
         running: true
         triggeredOnStart: true
         onTriggered: readData()
     }
-
 
     function readData() {
         var request = new XMLHttpRequest();
@@ -41,10 +29,9 @@ GridLayout {
                 if (request.status == 200) {
                     var j = JSON.parse(request.responseText);
                     var bgs = j.bgs[0];
-                    var trend = trend_arrows[bgs.trend];
+                    var trend = trendArrows[bgs.trend];
 
                     currentBG.text = bgs.sgv + " mg/dl " + trend;
-                    currentBG.color = "white";
                 }
             }
         }
@@ -53,7 +40,7 @@ GridLayout {
             nightscoutURL = nightscoutURL.substring(1);
         }
 
-        request.open("GET", nightscoutURL + "/pebble");
+        request.open("GET", nightscoutURL + "/pebble/?token=" + nightscoutToken);
         request.send();
     }
 }

--- a/contents/ui/ConfigLayout.qml
+++ b/contents/ui/ConfigLayout.qml
@@ -1,28 +1,24 @@
-import QtMultimedia 5.8
-import QtQuick 2.7
-import QtQuick.Controls 1.4
-import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.3
+import QtQuick 2.0
+import QtQuick.Controls 2.5 as QQC2
+import org.kde.kirigami 2.4 as Kirigami
 
-import org.kde.plasma.core 2.0 as PlasmaCore
+Kirigami.FormLayout {
+    id: page
 
-Item {
     property alias cfg_nightscoutURL: nightscoutURL.text
+    property alias cfg_nightscoutToken: nightscoutToken.text
+    property alias cfg_updateInterval: updateInterval.value
 
-    GridLayout {
-        width: parent.width
-        columns: 2
-
-        Text {
-            text: "Your Nightscout url (e.g. https://appname.herokuapp.com)"
-            color: "white"
-            Layout.alignment: Qt.AlignRight
-        }
-
-        TextField {
-            id: nightscoutURL
-            Layout.fillWidth: true
-            placeholderText: "https://"
-        }
+    QQC2.TextField {
+        id: nightscoutURL
+        Kirigami.FormData.label: i18n("Nightscout URL")
+    }
+    QQC2.TextField {
+        id: nightscoutToken
+        Kirigami.FormData.label: i18n("Nightscout API token")
+    }
+    QQC2.SpinBox {
+        id: updateInterval
+        Kirigami.FormData.label: i18n("Update Interval (minutes)")
     }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -10,10 +10,12 @@ import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.plasmoid 2.0
 
 Item {
-    property int read_interval: 30000
-    property variant trend_arrows: ["", "↟", "↑", "↗", "→", "↘", "↓", "↡", "↮", "↺"]
+    property variant trendArrows: ["", "↟", "↑", "↗", "→", "↘", "↓", "↡", "↮", "↺"]
     property string nightscoutURL: Plasmoid.configuration.nightscoutURL
+    property string nightscoutToken: Plasmoid.configuration.nightscoutToken
+    property int updateInterval: Plasmoid.configuration.updateInterval
 
+    Plasmoid.preferredRepresentation: Plasmoid.compactRepresentation
     Plasmoid.compactRepresentation: CompactRepresentation { }
 
 }


### PR DESCRIPTION
By supporting the API tokens of NS, state-of-the-art instances are supported.
Additional, some modernization/cleanup of the code was done.

### Configuration
![image](https://github.com/cominixo/nightscout-widget-kde/assets/6933385/675ef527-d3c9-4489-8a76-894f6710df73)

### Example (new "slimmer" look)
![image](https://github.com/cominixo/nightscout-widget-kde/assets/6933385/47a9ea09-e15b-4b22-bd9d-020a0f96e93a)

